### PR TITLE
Update publishing format for gripper topics

### DIFF
--- a/TeleopSoftware/launch.py
+++ b/TeleopSoftware/launch.py
@@ -67,7 +67,7 @@ class GUI(Node):
             pubs[arm+"_q"] = self.create_publisher(Float32MultiArray, f"/{arm.lower()}_q", 10)
             pubs[arm+"_cartesian"] = self.create_publisher(Float32MultiArray, f"/{arm.lower()}_cartesian_eef", 10)
             pubs[arm+"_speed"] = self.create_publisher(Float32MultiArray, f"/{arm.lower()}_speed", 10)
-            pubs[arm+"_gripper"] = self.create_publisher(Float32, f"/{arm.lower()}_gripper", 10)
+            pubs[arm+"_gripper"] = self.create_publisher(Int32, f"/{arm.lower()}_gripper", 10)
             pubs[arm+"_enable"] = self.create_publisher(Bool, f"/{arm.lower()}_enable", 10)
             pubs[arm+"_safety_mode"] = self.create_publisher(Int32, f"/{arm.lower()}_safety_mode", 10)
             # # Force offset

--- a/TeleopSoftware/launch_helpers/run.py
+++ b/TeleopSoftware/launch_helpers/run.py
@@ -294,7 +294,7 @@ def ros_update(fields, ros_data, control_modes, URs, pubs, optimize):
             pubs[arm+"_speed"].publish(Float32MultiArray(data=speed))
 
             gripper = URs.get_gripper(arm).get_current_position()
-            pubs[arm+"_gripper"].publish(Float32(data=gripper))
+            pubs[arm+"_gripper"].publish(Int32(data=gripper))
 
             enable = spark_enable[arm] if arm in spark_enable else False
             pubs[arm+"_enable"].publish(Bool(data=enable))


### PR DESCRIPTION
ROS topics for the UR5 grippers '/lightning_gripper' and 'thunder_gripper' were publishing null data
Float32 -> Int32 fixes this issue